### PR TITLE
Fix mobile nav toggling

### DIFF
--- a/script.js
+++ b/script.js
@@ -2,9 +2,9 @@
 function toggleMenu(){
     const nav = document.getElementById('nav');
     const btn = document.querySelector('.menu');
-    const isOpen = nav.style.display === 'flex';
-    nav.style.display = isOpen ? 'none' : 'flex';
-    btn.setAttribute('aria-expanded', String(!isOpen));
+    if(!nav || !btn) return;
+    const isOpen = nav.classList.toggle('open');
+    btn.setAttribute('aria-expanded', String(isOpen));
   }
   
   // Theme handling (black or white only) with persistence
@@ -180,7 +180,7 @@ function toggleMenu(){
           
           // Close mobile menu if open
           const nav = document.getElementById('nav');
-          if (nav.style.display === 'flex') {
+          if (nav.classList.contains('open')) {
             toggleMenu();
           }
         }
@@ -304,7 +304,7 @@ function toggleMenu(){
     // 'Escape' closes mobile menu
     if(e.key === 'Escape'){
       const nav = document.getElementById('nav');
-      if(nav.style.display === 'flex'){
+      if(nav.classList.contains('open')){
         toggleMenu();
       }
     }

--- a/styles.css
+++ b/styles.css
@@ -586,6 +586,7 @@
   @media (max-width:900px){
     .grid-2{grid-template-columns:1fr}
     .nav{display:none}
+    .nav.open{display:flex}
     .menu{display:block}
   }
   
@@ -850,6 +851,10 @@
       padding: 12px 16px;
       animation: slideDown 0.3s ease-out;
       backdrop-filter: saturate(180%) blur(20px);
+    }
+
+    .nav.open {
+      display: flex;
     }
     
     @keyframes slideDown {


### PR DESCRIPTION
## Summary
- switch mobile nav toggle to class-based `open` state instead of inline display
- adjust handlers to use new `open` class
- add CSS rules for `.nav.open` to display menu on small screens

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a16845af60832d9550b813a2545d4b