### PR TITLE
Default to light theme before JS

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" data-theme="light">
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/script.js
+++ b/script.js
@@ -42,7 +42,7 @@ function toggleMenu(){
     const btn = document.getElementById('themeToggle');
     const saved = localStorage.getItem('theme');
     const prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
-    const initial = saved || (prefersDark ? 'dark' : 'light');
+    const initial = saved || 'light';
   
     function setTheme(mode){
       root.setAttribute('data-theme', mode);


### PR DESCRIPTION
## Summary
- set the html element to default to the light theme attribute before scripts run
- update the theme initialization script to default to the light theme when no preference is stored

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cf046dcf50832dad7cba68264e9096